### PR TITLE
v0.16.9

### DIFF
--- a/AOK_VARS
+++ b/AOK_VARS
@@ -25,7 +25,7 @@
 #  Label for AOK builds, is also displayed by motd to indicate what
 #  AOK FS release is being used
 #
-AOK_VERSION="0.16.8a"
+AOK_VERSION="0.16.8g"
 
 #
 #  If defined this will be created as a no-password sudo capable user

--- a/Alpine/setup_alpine.sh
+++ b/Alpine/setup_alpine.sh
@@ -199,16 +199,7 @@ else
     "$setup_final"
 fi
 
-[ -n "$PREBUILD_ADDITIONAL_TASKS" ] && {
-    msg_1 "Running additional setup tasks"
-    echo "---------------"
-    echo "$PREBUILD_ADDITIONAL_TASKS"
-    echo "---------------"
-    $PREBUILD_ADDITIONAL_TASKS || {
-        error_msg "PREBUILD_ADDITIONAL_TASKS returned error"
-    }
-    msg_1 "Returned from the additional prebuild tasks"
-}
+additional_prebuild_tasks
 
 display_installed_versions_if_prebuilt
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ I will try to keep track of changes between releases here
 
 ## Upcomming release, available in main branch
 
+- currently at v0.16.9
+- error_msg supports exit code < 0
+- handling case where chroot was used for prebuild, but dest is native
+- better handling of chroot hostname
 - split up some huge functions into parts
 - currently at v0.16.8a
 - halt: added sleep after kills

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ I will try to keep track of changes between releases here
 
 ## Upcomming release, available in main branch
 
+- split up some huge functions into parts
 - currently at v0.16.8a
 - halt: added sleep after kills
 - currently at v0.16.8

--- a/Debian/setup_debian.sh
+++ b/Debian/setup_debian.sh
@@ -78,16 +78,7 @@ else
     "$setup_final"
 fi
 
-[ -n "$PREBUILD_ADDITIONAL_TASKS" ] && {
-    msg_1 "Running additional setup tasks"
-    echo "---------------"
-    echo "$PREBUILD_ADDITIONAL_TASKS"
-    echo "---------------"
-    $PREBUILD_ADDITIONAL_TASKS || {
-        error_msg "PREBUILD_ADDITIONAL_TASKS returned error"
-    }
-    msg_1 "Returned from the additional prebuild tasks"
-}
+additional_prebuild_tasks
 
 display_installed_versions_if_prebuilt
 

--- a/Devuan/setup_devuan.sh
+++ b/Devuan/setup_devuan.sh
@@ -80,16 +80,7 @@ else
     "$setup_final"
 fi
 
-[ -n "$PREBUILD_ADDITIONAL_TASKS" ] && {
-    msg_1 "Running additional setup tasks"
-    echo "---------------"
-    echo "$PREBUILD_ADDITIONAL_TASKS"
-    echo "---------------"
-    $PREBUILD_ADDITIONAL_TASKS || {
-        error_msg "PREBUILD_ADDITIONAL_TASKS returned error"
-    }
-    msg_1 "Returned from the additional prebuild tasks"
-}
+additional_prebuild_tasks
 
 display_installed_versions_if_prebuilt
 

--- a/common_AOK/setup_common_env.sh
+++ b/common_AOK/setup_common_env.sh
@@ -34,16 +34,165 @@ copy_skel_files() {
     # echo "^^^ copy_skel_files($1) - done"
 }
 
+user_shell() {
+    #
+    #  If USER_SHELL has been defined, the assumption would be to use
+    #  the same for user root, since if logins are not enabled,
+    #  you wold start up as user root.
+    #
+    #  Only allow root to get bash or ash during deploy, in order to
+    #  ensure /etc/profile will be launched and deployt can complete
+    #
+
+    if [ "$USER_SHELL" = "/bin/ash" ] || [ "$USER_SHELL" = "/bin/bash" ]; then
+        msg_3 "Setting root shell into USER_SHELL: $USER_SHELL"
+        awk -v shell="$USER_SHELL" -F: '$1=="root" {$NF=shell}1' OFS=":" \
+            /etc/passwd >/tmp/passwd && mv /tmp/passwd /etc/passwd
+    fi
+}
+
+handle_hardcoded_tz() {
+    #
+    #  If AOK_TIMEZONE is defined, TZ can be set as early as the tools
+    #  needed for it are in. If it is not set, there will be a dialog
+    #  at the end of the deploy where TZ can be selected
+    #
+    if [ -n "$AOK_TIMEZONE" ]; then
+        #
+        #  Need full path to handle that this path is not correctly cached at
+        #  this point if Debian is being installed, probably due to switching
+        #  from Alpine to Debian without having rebooted yet.
+        #
+        msg_2 "Setitng time zone"
+        msg_3 "Using hardcoded TZ: $AOK_TIMEZONE"
+        ln -sf "/usr/share/zoneinfo/$AOK_TIMEZONE" /etc/localtime
+    fi
+}
+
+adding_runbg_service() {
+    if command -v openrc >/dev/null; then
+        msg_2 "Adding runbg service"
+        rsync_chown /opt/AOK/common_AOK/etc/init.d/runbg /etc/init.d silent
+        # openrc_might_trigger_errors
+        rc-update add runbg default
+    else
+        msg_2 "openrc not available - runbg not activated"
+        error_msg "><> openrc not available - runbg not activated"
+    fi
+}
+
+removing_original_hostname_service() {
+    #
+    #  Removing default hostname service
+    #
+    hostn_service=/etc/init.d/hostname
+    if [ -f "$hostn_service" ]; then
+        msg_2 "Disabling hostname service not working on iSH"
+        mv -f "$hostn_service" /etc/init.d/NOT-hostname
+    fi
+    if destfs_is_debian || destfs_is_devuan; then
+        msg_3 "Removing hostname service files not meaningfull on iSH"
+        rm -f /etc/init.d/hostname
+        rm -f /etc/init.d/hostname.sh
+        rm -f /etc/rcS.d/S01hostname.sh
+        rm -f /etc/systemd/system/hostname.service
+    fi
+}
+
+changing_sshd_port() {
+    if [ -f /etc/ssh/sshd_config ]; then
+        # Move sshd to port 1022 to avoid issues
+        sshd_port=1022
+        msg_2 "sshd will use port: $sshd_port"
+        sed -i "/Port /c\\Port $sshd_port" /etc/ssh/sshd_config
+        #sed -i "s/.*Port .*/Port $sshd_port/" /etc/ssh/sshd_config
+        unset sshd_port
+    else
+        msg_2 "sshd not installed - port not changed"
+    fi
+}
+
 setup_cron_env() {
     msg_2 "Setup general cron env"
     #
     #  These files will always be setup and ready
     #  The cron/dcron service will only be acrive
-    #  if USE_CRON_SERVICE="Y
+    #  if USE_CRON_SERVICE="Y >$f_hostname_org"
     #
     msg_3 "Setting cron periodic files"
     rsync_chown /opt/AOK/common_AOK/cron/periodic /etc silent
     #msg_3 "setup_cron_env() - done"
+}
+
+replace_std_bin() {
+    f_bin="$1"
+    f_bin_replacement="$2"
+
+    [ -z "$f_bin" ] && error_msg "replace_std_bin() - missing 1st param"
+    [ -z "$f_bin_replacement" ] && {
+        error_msg "replace_std_bin($f_bin,) - missing 2nd param"
+    }
+
+    f_bin_org="$(dirname "$f_bin")/ORG.$(basename "$f_bin")"
+    if [ ! -f "$f_bin_org" ]; then
+        if [ -f "$f_bin" ]; then
+            msg_4 "Renaming original $f_bin -> $f_bin_org"
+            mv "$f_bin" "$f_bin_org"
+        else
+            msg_4 "Original $f_bin - not found"
+        fi
+    else
+        error_msg "$f_hostname_org already pressent, removing $f_bin" -1
+        rm -f "$f_bin"
+    fi
+
+    msg_3 "Softlinking $f_bin_replacement -> $f_bin"
+    ln -sf "$f_bin_replacement" "$f_bin"
+}
+
+replacing_std_bins_with_aok_versions() {
+    #
+    #  Replacing some stadard bins with AOK version
+    #
+    msg_2 "Replacing std bins wirh AOK versions"
+
+    _f=/usr/bin/hostname
+    [ ! -f "$_f" ] && _f=/bin/hostname
+    $_f -s >"$f_hostname_initial" # Used by utils:set_hostname()
+    replace_std_bin "$_f" /usr/local/bin/hostname
+
+    replace_std_bin /usr/bin/wall /usr/local/bin/wall
+    replace_std_bin /sbin/shutdown /usr/local/sbin/shutdown
+    replace_std_bin /sbin/halt /usr/local/sbin/halt
+    replace_std_bin /sbin/poweroff /usr/local/sbin/halt
+    echo
+}
+
+disabling_default_services() {
+    #
+    #  openrc is extreamly forgiving when it comes to dependencies, any
+    #  dependency that is not pressent is simply ignored.
+    #
+    #  When doing start/stop no more weird openrc warnings from kernel
+    #  related services that will always fail on iSH
+    #
+    #  Bootup time is vastly reduced, since openrc doesn't have to plow
+    #  through essentially every init script due to complex and in our
+    #  case pointless dependencies
+    #
+    msg_3 "Moving all unused services to /etc/init.d/NOT"
+    mv /etc/init.d /etc/NOT
+    mkdir /etc/init.d
+    mv /etc/NOT /etc/init.d
+    #  Keep the files we actually need
+    if destfs_is_alpine; then
+        cp -a /etc/init.d/NOT/sshd /etc/init.d
+    else
+        cp -a /etc/init.d/NOT/ssh /etc/init.d
+        msg_4 "Preserving /etc/init.d/rc"
+        cp -a /etc/init.d/NOT/rc /etc/init.d
+    fi
+    msg_4 "Unused files cleared from init.d"
 }
 
 setup_environment() {
@@ -72,30 +221,7 @@ setup_environment() {
     msg_3 "Installing profile-hints file"
     cp /opt/AOK/common_AOK/etc/profile-hints /etc
 
-    #
-    #  openrc is extreamly forgiving when it comes to dependencies, any
-    #  dependency that is not pressent is simply ignored.
-    #
-    #  When doing start/stop no more weird openrc warnings from kernel
-    #  related services that will always fail on iSH
-    #
-    #  Bootup time is vastly reduced, since openrc doesn't have to plow
-    #  through essentially every init script due to complex and in our
-    #  case pointless dependencies
-    #
-    msg_3 "Moving all unused services to /etc/init.d/NOT"
-    mv /etc/init.d /etc/NOT
-    mkdir /etc/init.d
-    mv /etc/NOT /etc/init.d
-    #  Keep the files we actually need
-    if destfs_is_alpine; then
-        cp -a /etc/init.d/NOT/sshd /etc/init.d
-    else
-        cp -a /etc/init.d/NOT/ssh /etc/init.d
-        msg_4 "Preserving /etc/init.d/rc"
-        cp -a /etc/init.d/NOT/rc /etc/init.d
-    fi
-    msg_4 "Unused files cleared from init.d"
+    disabling_default_services
 
     msg_3 "Populate /etc/skel"
     rsync_chown /opt/AOK/common_AOK/etc/skel /etc silent
@@ -108,120 +234,12 @@ setup_environment() {
 
     echo >>/etc/issue
 
-    #
-    #  If USER_SHELL has been defined, the assumption would be to use
-    #  the same for user root, since if logins are not enabled,
-    #  you wold start up as user root.
-    #
-    #  Only allow root to get bash or ash during deploy, in order to
-    #  ensure /etc/profile will be launched and deployt can complete
-    #
-
-    if [ "$USER_SHELL" = "/bin/ash" ] || [ "$USER_SHELL" = "/bin/bash" ]; then
-        msg_3 "Setting root shell into USER_SHELL: $USER_SHELL"
-        awk -v shell="$USER_SHELL" -F: '$1=="root" {$NF=shell}1' OFS=":" \
-            /etc/passwd >/tmp/passwd && mv /tmp/passwd /etc/passwd
-    fi
-
-    #
-    #  If AOK_TIMEZONE is defined, TZ can be set as early as the tools
-    #  needed for it are in. If it is not set, there will be a dialog
-    #  at the end of the deploy where TZ can be selected
-    #
-    if [ -n "$AOK_TIMEZONE" ]; then
-        #
-        #  Need full path to handle that this path is not correctly cached at
-        #  this point if Debian is being installed, probably due to switching
-        #  from Alpine to Debian without having rebooted yet.
-        #
-        msg_2 "Setitng time zone"
-        msg_3 "Using hardcoded TZ: $AOK_TIMEZONE"
-        ln -sf "/usr/share/zoneinfo/$AOK_TIMEZONE" /etc/localtime
-    fi
-
-    # #
-    # #  Too much of a hack, need ot preserve sshd and so on...
-    # #
-    # msg_1 "Moving all initial init.d scripts to a NOT subfolder"
-    # mkdir -p /etc/NOT &&
-    #     mv /etc/init.d/* /etc/NOT &&
-    #     mv /etc/NOT /etc/init.d &&
-    #     cd /etc/init.d &&
-    #     mv NOT/functions.sh . &&
-    #     mv NOT/sshd . || error_msg "init.d cleanup failed"
-
-    if command -v openrc >/dev/null; then
-        msg_2 "Adding runbg service"
-        rsync_chown /opt/AOK/common_AOK/etc/init.d/runbg /etc/init.d silent
-        # openrc_might_trigger_errors
-        rc-update add runbg default
-    else
-        msg_2 "openrc not available - runbg not activated"
-        error_msg "><> openrc not available - runbg not activated"
-    fi
-
-    #
-    #  Removing default hostname service
-    #
-    hostn_service=/etc/init.d/hostname
-    if [ -f "$hostn_service" ]; then
-        msg_2 "Disabling hostname service not working on iSH"
-        mv -f "$hostn_service" /etc/init.d/NOT-hostname
-    fi
-    if destfs_is_debian || destfs_is_devuan; then
-        msg_3 "Removing hostname service files not meaningfull on iSH"
-        rm -f /etc/init.d/hostname
-        rm -f /etc/init.d/hostname.sh
-        rm -f /etc/rcS.d/S01hostname.sh
-        rm -f /etc/systemd/system/hostname.service
-    fi
-
-    #
-    #  Replacing some stadard bins with AOK version
-    #
-    _f=/usr/bin/wall
-    msg_2 "soft-linking $_f to /usr/local/bin/wall"
-    [ -f "$_f" ] && [ ! -L "$_f" ] && {
-        msg_3 "Saving org $_f"
-        mv "$_f" /usr/bin/ORG.wall
-    }
-    ln -sf /usr/local/bin/wall /usr/bin
-
-    _f=/sbin/shutdown
-    msg_2 "soft-linking $_f to /usr/local/sbin/shutdown"
-    [ -f "$_f" ] && [ ! -L "$_f" ] && {
-        msg_3 "Saving org $_f"
-        mv "$_f" /sbin/ORG.shutdown
-    }
-    ln -sf /usr/local/sbin/shutdown /sbin
-
-    _f=/sbin/halt
-    msg_2 "soft-linking $_f to /usr/local/sbin/halt"
-    [ -f "$_f" ] && [ ! -L "$_f" ] && {
-        msg_3 "Saving org $_f"
-        mv "$_f" /sbin/ORG.halt
-    }
-    ln -sf /usr/local/sbin/halt /sbin
-
-    _f=/sbin/poweroff
-    msg_2 "soft-linking $_f to /usr/local/sbin/halt"
-    [ -f "$_f" ] && [ ! -L "$_f" ] && {
-        msg_3 "Saving org $_f"
-        mv "$_f" /sbin/ORG.poweroff
-    }
-
-    ln -sf /usr/local/sbin/halt /sbin/poweroff
-
-    if [ -f /etc/ssh/sshd_config ]; then
-        # Move sshd to port 1022 to avoid issues
-        sshd_port=1022
-        msg_2 "sshd will use port: $sshd_port"
-        sed -i "/Port /c\\Port $sshd_port" /etc/ssh/sshd_config
-        #sed -i "s/.*Port .*/Port $sshd_port/" /etc/ssh/sshd_config
-        unset sshd_port
-    else
-        msg_2 "sshd not installed - port not changed"
-    fi
+    user_shell
+    handle_hardcoded_tz
+    adding_runbg_service
+    removing_original_hostname_service
+    replacing_std_bins_with_aok_versions
+    changing_sshd_port
 
     msg_2 "Set default aok preferences"
     #
@@ -229,7 +247,7 @@ setup_environment() {
     # on first boot aok -s on  will be set
     #
     aok -c off -H on -s off -C off
-    # only set if not chrootedgeeral
+    # only set if not chrooted
     this_fs_is_chrooted || aok -l aok
 
     setup_cron_env

--- a/common_AOK/setup_common_env.sh
+++ b/common_AOK/setup_common_env.sh
@@ -375,6 +375,7 @@ else
 fi
 
 setup_environment
+set_hostname
 setup_root_env
 create_user
 

--- a/common_AOK/setup_final_tasks.sh
+++ b/common_AOK/setup_final_tasks.sh
@@ -119,21 +119,31 @@ hostname_fix() {
 
 aok_kernel_consideration() {
     msg_2 "aok_kernel_consideration()"
-    if ! this_is_aok_kernel; then
-        if ! min_release 3.18; then
+    this_is_aok_kernel || {
+        msg_3 "Not aok kernel!"
+        min_release 3.18 || {
             msg_3 "procps wont work on regular iSH for Alpine < 3.18"
             apk del procps || {
                 error_msg "apk del procps failed"
             }
-        fi
-    elif [ -n "$AOK_APKS" ]; then
+        }
+        return
+    }
+
+    [ -n "$AOK_APKS" ] && {
         msg_3 "Install packages only for AOK kernel"
         # In this case we want the variable to expand into its components
         # shellcheck disable=SC2086
         apk add $AOK_APKS || {
             error_msg "apk add AOK_APKS failed"
         }
-    fi
+    }
+
+    # shellcheck disable=SC2154
+    this_is_aok_kernel && [ "$AOK_HOSTNAME_SUFFIX" = "Y" ] && {
+        msg_3 "Using -aok suffix"
+        aok -s on
+    }
     # msg_3 "aok_kernel_consideration() - done"
 }
 

--- a/tools/upgrade-aok-fs.sh
+++ b/tools/upgrade-aok-fs.sh
@@ -276,6 +276,7 @@ check_softlinks() {
         f_org_halt="/sbin/ORG.halt"
         f_org_shutdown="/sbin/ORG.shutdown"
     fi
+
     should_be_softlink "$d_hostname"/hostname \
         /usr/local/bin/hostname "$d_hostname"/ORG.hostname
     should_be_softlink /sbin/halt /usr/local/sbin/halt "$f_org_halt"

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -1004,6 +1004,22 @@ set_hostname() {
         hostname -S "$ALT_HOSTNAME_SOURCE_FILE" || {
             error_msg "Failed to soure alt file"
         }
+    elif ! this_fs_is_chrooted && [ -f "$f_chroot_hostname" ]; then
+        msg_3 "was pre-built chrooted, but now runs native"
+        rm -f "$f_chroot_hostname"
+        if hostfs_is_alpine; then
+            hname="$(busybox hostname)"
+        elif command -v ORG.hostname >/dev/null; then
+            hname="$(ORG.hostname)"
+        else
+            hname="unknown"
+        fi
+        [ -n "$hname" ] && {
+            _f=/etc/opt/AOK/detected-hostname
+            msg_3 "Saved detected hostname [$hname] in: $_f"
+            echo "$hname" >"$_f"
+            hostname -S "$_f"
+        }
     fi
     #  Ensure hostname has been picked up
     hostname -U >/dev/null

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -24,11 +24,6 @@ error_msg() {
         echo
         echo "error_msg() no param"
         exit 9
-    elif [ "$_em_exit_code" = "0" ]; then
-        echo
-        echo "error_msg() second parameter was 0"
-        echo "            if continuation is desired use no_exit"
-        exit 9
     fi
 
     _em_msg="ERROR[$0]: $_em_msg"
@@ -36,8 +31,8 @@ error_msg() {
     echo "$_em_msg"
     echo
 
-    if [ "$_em_exit_code" = "no_exit" ]; then
-        echo "no_exit given, will continue"
+    if [ "$_em_exit_code" -lt 0 ]; then
+        echo "exit code: $_em_exit_code given - will continue"
         echo
     else
         exit "$_em_exit_code"

--- a/tools/utils.sh
+++ b/tools/utils.sh
@@ -750,6 +750,23 @@ destfs_detect() {
     fi
 }
 
+additional_prebuild_tasks() {
+    #
+    #  Additional tasks that could be run during pre-build, ie
+    #  doesnt have to happen on destination platform
+    #
+    [ -n "$PREBUILD_ADDITIONAL_TASKS" ] && {
+        msg_1 "Running additional setup tasks"
+        echo "---------------"
+        echo "$PREBUILD_ADDITIONAL_TASKS"
+        echo "---------------"
+        $PREBUILD_ADDITIONAL_TASKS || {
+            error_msg "PREBUILD_ADDITIONAL_TASKS returned error"
+        }
+        msg_1 "Returned from the additional prebuild tasks"
+    }
+}
+
 #---------------------------------------------------------------
 #
 #   lsb-release
@@ -889,6 +906,12 @@ deploy_state_check_param() {
     unset _func
     unset bspc_bs
 }
+
+#---------------------------------------------------------------
+#
+#   Other
+#
+#---------------------------------------------------------------
 
 deploy_starting() {
     if [ "$build_env" = "$be_other" ]; then


### PR DESCRIPTION
- currently at v0.16.9
- error_msg supports exit code < 0
- handling case where chroot was used for prebuild, but dest is native
- better handling of chroot hostname
- split up some huge functions into parts
- halt: added sleep after kills
